### PR TITLE
Fix andromeda + lista archivos

### DIFF
--- a/_maps/shuttles/shiptestHISPANIA/descorp_andromeda.dmm
+++ b/_maps/shuttles/shiptestHISPANIA/descorp_andromeda.dmm
@@ -2717,7 +2717,6 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
-/obj/machinery/door/window/brigdoor/eastright,
 /turf/open/floor/engine,
 /area/ship/engineering)
 "wX" = (
@@ -4241,8 +4240,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ship/bridge)
 "IK" = (
-/obj/machinery/atmospherics/components/binary/volume_pump/on/layer4{
-	/obj/machinery/atmospherics/components/binary/pump/layer4{dir = 8;
+/obj/machinery/atmospherics/components/binary/volume_pump/layer4{
 	dir = 8
 	},
 /turf/open/floor/plasteel/mono/dark,
@@ -6585,7 +6583,7 @@ Kg
 "}
 (2,1,1) = {"
 Ig
-Ig
+bH
 BR
 BR
 BR
@@ -6613,7 +6611,7 @@ Fb
 Wo
 Wo
 Wo
-Ig
+bH
 Ig
 "}
 (3,1,1) = {"

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -3682,9 +3682,9 @@
 #include "code\modules\vending\youtool.dm"
 #include "code\modules\zombie\items.dm"
 #include "code\modules\zombie\organs.dm"
-#include "modular_hispania\code\game\objects\items\coins.dm"
 #include "interface\interface.dm"
 #include "interface\menu.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
+#include "modular_hispania\code\game\objects\items\coins.dm"
 // END_INCLUDE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Arregla un pequeño error de mapeo de la andromeda que causaba que una pipe no se pusiera correctamente y spawneaba una bridgedoor en medio de un pasillo. También activa los ficheros no listados que causan que la ropa de los jobs no funcionara.