### PR TITLE
Prefijos custom

### DIFF
--- a/code/modules/overmap/helm.dm
+++ b/code/modules/overmap/helm.dm
@@ -306,7 +306,7 @@
 			if(!reject_bad_text(new_name, MAX_CHARTER_LEN) || CHAT_FILTER_CHECK(new_name))
 				say("Error: Replacement designation rejected by system.")
 				return
-			if(tgui_alert(usr, "Are you sure you want to rename the ship to the \"[current_ship.source_template.prefix] [new_name]\"?", "Rename Confirmation", list("Yes", "No")) != "Yes")
+			if(tgui_alert(usr, "Are you sure you want to rename the ship to the \"[new_name]\"?", "Rename Confirmation", list("Yes", "No")) != "Yes")
 				return
 			if(!current_ship.Rename(new_name))
 				say("Error: [COOLDOWN_TIMELEFT(current_ship, rename_cooldown)/10] seconds until ship designation can be changed.")

--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -86,7 +86,7 @@
 
 /datum/overmap/ship/controlled/Rename(new_name, force = FALSE)
 	var/old_name = name
-	var/full_name = "[source_template.prefix] [new_name]"
+	var/full_name = "[new_name]"
 	if(!force && !COOLDOWN_FINISHED(src, rename_cooldown) || !..(full_name, force))
 		return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Este pequeño cambio hace que la nave ya no tenga prefijos predefinidos, haciendo que cualquier jugador pueda ponerle el nombre que quiera y el prefijo que desee

## Why It's Good For The Game

Ya nadie tiene que usar los prefijos predefinicos de la nave

## Changelog

:cl:

code: Los jugadores pueden poner cualquier nombre a su nave, con o sin prefijos

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
